### PR TITLE
ensure proper relationships

### DIFF
--- a/custom_objects/objects/misphunter-seed/definition.json
+++ b/custom_objects/objects/misphunter-seed/definition.json
@@ -41,6 +41,12 @@
             "misp-attribute": "text",
             "disable_correlation": true,
             "ui-priority": 0
+        },
+        "found-host": {
+            "description": "Host that was discovered using this search.",
+            "misp-attribute": "ip-dst",
+            "disable_correlation": false,
+            "ui-priority": 0
         }
     },
     "description": "Object holds the raw searches that populate the rest of the event. This should be the first thing you make for a misphunter event.",
@@ -52,5 +58,5 @@
         "enabled"
     ],
     "uuid": "a891fc40-fad2-11eb-a495-000d3a98c781",
-    "version": 2
+    "version": 3
 }

--- a/lib/misphandler.py
+++ b/lib/misphandler.py
@@ -119,8 +119,8 @@ def build_misphunter_cert(misphunter, cert, parent_obj, event, raw_data):
             cert_obj.add_attribute('cert-domain', domain, type="domain", disable_correlation=False, to_ids=False, pythonify=True)
 
     # Add relationship
-    comment=f"Certificate was seen on {ip}"
-    cert_obj.add_reference(parent_obj.uuid, "derived-from", comment=comment)
+    # comment=f"Certificate was seen on {ip}"
+    # cert_obj.add_reference(parent_obj.uuid, "derived-from", comment=comment)
 
     sha256 = parsed_data['fingerprint_sha256']
     if 'new_certs' not in misphunter.run_stats:
@@ -153,8 +153,8 @@ def build_new_host_obj(misphunter, event, seed, ip):
     for attr in host_obj.Attribute:
         update_timestamps(attr)
     # Define relationship
-    ref_comment = f"{ip} derived from {service} search"
-    host_obj.add_reference(seed.uuid, "derived-from", comment=ref_comment)
+    # ref_comment = f"{ip} derived from {service} search"
+    # host_obj.add_reference(seed.uuid, "derived-from", comment=ref_comment)
 
     if 'new_hosts' not in misphunter.run_stats:
         misphunter.run_stats['new_hosts'] = {str(event.id) : [ip]}
@@ -502,10 +502,12 @@ def get_host_obj(misphunter, event, seed, ip):
         _log.info(f"No existing object found server-wide. Building new host_obj.")
         host_obj = build_new_host_obj(misphunter, event, seed, ip)
     else:
+        '''
         if existing_obj.is_new:
             service = get_attr_val_by_rel(seed, 'service')
             ref_comment = f"{ip} derived from {service} search"
             existing_obj.add_reference(seed.uuid, "derived-from", comment=ref_comment)
+        '''
         return existing_obj
             
     return host_obj

--- a/misphunter.py
+++ b/misphunter.py
@@ -149,10 +149,9 @@ class MISPHunter():
             # TODO
             # Second, process all enabled misphunter objects for this event that were not touched after process_seeds()
 
-            # TODO
             # Third, run relationships/relationship checks against all objects in the event.
+            event = huntlogic.process_relationships(self, event)
 
-            # TODO
             # Finally, set blacklisted=1 for objects that have a crappy return (e.g. certs with only 1 assoc. host)
             #   or dns/domain objects that are clearly shared hosts
             event = huntlogic.auto_blacklist(self, event)


### PR DESCRIPTION
Addresses #2  - also removes all previous instances of derived-from as they became redundant once this function was complete.

Currently relates seeds -> hosts and certs -> hosts. Will need additional functions in the future when other misphunter objects are added.